### PR TITLE
Template to list all categories and tags alphabetically

### DIFF
--- a/style.css
+++ b/style.css
@@ -1983,6 +1983,52 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 
+/* Categories & Tags Template ---------------------------- */
+
+.tags_grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  justify-items: stretch;
+  column-gap: 15px;
+  row-gap: 10px;
+}
+
+.tags_grid h2 {
+  grid-column: 1/ -1;
+}
+
+.tags_grid .tag-cloud-link {
+  border-bottom: 2px solid #000;
+  text-decoration: none;
+  color: #000;
+  overflow: hidden;
+  line-height: 40px;
+}
+
+.tags_grid + .tags_grid {
+  margin-top: 40px;
+}
+
+.tags_grid .tag-cloud-link .tagcount {
+  display: inline-block;
+  background: #000;
+  color: #fff;
+  padding: 0 8px;
+  float: right;
+  width: 46px;
+  text-align: center;
+  line-height: 40px;
+  border: 2px solid transparent;
+  border-bottom: 0;
+}
+
+.tags_grid .tag-cloud-link:hover .tagcount {
+  background: none;
+  color: #000;
+  border: 2px solid #000;
+  border-bottom: 0;
+}
+
 /* -------------------------------------------------------------------------------- */
 /*	11.	Search
 /* -------------------------------------------------------------------------------- */
@@ -2463,6 +2509,17 @@ input.search-field::-moz-placeholder { color: #121212; }
 		margin: 80px 0 -28px -300px;
 		padding: 50px calc( 100% - 20px ) 0 0;
 	}
+      
+        .tags_grid {
+	       grid-template-columns: repeat(1, 1fr);
+	       width: 92%;
+	       margin-left: 15px;
+	}
+
+       .tags_grid .tag-cloud-link .tagcount {
+	      width: 46px;
+	      padding: 0 5px;
+        }
 
 	/* Entry Content ------------------------- */
 

--- a/topics.php
+++ b/topics.php
@@ -1,0 +1,78 @@
+<?php
+
+/* Template Name: Categories & Tags Template */
+/* Template Post Type: post, page */
+
+get_header(); ?>
+
+<div class="section-inner">
+
+		<header class="page-header">
+
+				<?php
+				the_title( '<h1 class="entry-title">', '</h1>' );
+
+				// Make sure we have a custom excerpt
+				if ( has_excerpt() ) {
+					echo '<p class="excerpt">' . get_the_excerpt() . '</p>';
+				}
+
+				// Only output post meta data on single
+				if ( is_single() || is_attachment() ) : ?>
+
+				<?php endif; ?>
+
+
+		</header><!-- .page-header -->
+
+	<div class="entry-content section-inner">
+				<?php the_content(); ?>
+
+			<hr>
+
+			<h2>Categories</h2>
+
+			<div class="tags_grid">
+
+			    <?php
+			    $categories = get_categories();
+			    if ($categories) :
+			        $count = 1;
+			        foreach ($categories as $category) : ?>
+			            <a href="<?php echo esc_url(get_category_link($category->term_id)); ?>" class="tag-cloud-link tag-link-<?php echo esc_attr($category->term_id); ?> tag-link-position-<?php echo esc_attr($count); ?>">
+			                <?php echo esc_html($category->name); ?><span class="tagcount"><?php echo esc_html($category->count); ?></span>
+			            </a>
+			            <?php $count++;
+			        endforeach;
+			    endif;
+			    ?>
+
+			</div><!-- .categories -->
+
+			<hr>
+
+			<h2>Tags</h2>
+			
+			<div class="tags_grid">
+			    <?php
+			    $tags = get_tags();
+			    if ($tags) :
+			        $count = 1;
+			        foreach ($tags as $tag) : ?>
+			            <a href="<?php echo esc_url(get_tag_link($tag->term_id)); ?>" class="tag-cloud-link tag-link-<?php echo esc_attr($tag->term_id); ?> tag-link-position-<?php echo esc_attr($count); ?>">
+			                <?php echo esc_html($tag->name); ?><span class="tagcount"><?php echo esc_html($tag->count); ?></span>
+			            </a>
+			            <?php $count++;
+			        endforeach;
+			    endif;
+			    ?>
+
+			</div> <!-- .tags -->
+
+	</div> <!-- .content -->
+
+</div><!-- .section-inner -->
+
+<?php
+
+get_footer(); ?>


### PR DESCRIPTION
Basically reproducing this layout with a few small changes: https://bellacaledonia.org.uk/tags

Notably, this layout lists categories and tags in two columns rather than four, to fit well with the existing design.